### PR TITLE
Add "support" for unsupported platforms.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,16 @@ repository = "https://github.com/Stebalien/xattr"
 keywords = ["xattr", "filesystem", "unix"]
 license = "MIT/Apache-2.0"
 
+[features]
+default = ["unsupported"]
+# Adds a dummy implementation for unsupported platforms. This is useful when
+# developing platform-independent code that doesn't absolutely need xattr
+# support.
+#
+# You can disable this feature if you want compilation to fail on unsupported
+# platforms. This would make sense if you absolutely need xattr support.
+unsupported = []
+
 [dependencies]
 libc = "0.2"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,25 @@
+use std::error::Error;
+use std::fmt;
+
+/// The error type returned on unsupported platforms.
+///
+/// On unsupported platforms, all operations will fail with an `io::Error` with
+/// a kind `io::ErrorKind::Other` and an `UnsupportedPlatformError` error as the inner error.
+/// While you *could* check the inner error, it's probably simpler just to check
+/// `xattr::SUPPORTED_PLATFORM`.
+///
+/// This error mostly exists for pretty error messages.
+#[derive(Copy, Clone, Debug)]
+pub struct UnsupportedPlatformError;
+
+impl Error for UnsupportedPlatformError {
+    fn description(&self) -> &str {
+        "unsupported platform"
+    }
+}
+
+impl fmt::Display for UnsupportedPlatformError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "unsupported platform, please file a bug at `https://github.com/Stebalien/xattr'")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ extern crate libc;
 
 mod sys;
 mod util;
+mod error;
 
 use std::os::unix::io::AsRawFd;
 use std::ffi::OsStr;
@@ -12,7 +13,8 @@ use std::io;
 use std::fs::File;
 use std::path::Path;
 
-pub use sys::XAttrs;
+pub use sys::{XAttrs, SUPPORTED_PLATFORM};
+pub use error::UnsupportedPlatformError;
 
 /// Get an extended attribute for the specified file.
 pub fn get<N, P>(path: P, name: N) -> io::Result<Vec<u8>>

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -10,16 +10,19 @@ mod bsd;
 #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
 pub use self::bsd::*;
 
-#[cfg(not(any(target_os = "freebsd", target_os = "netbsd", target_os = "macos", target_os = "linux")))]
+#[cfg(all(feature = "unsupported", not(any(target_os = "freebsd", target_os = "netbsd", target_os = "macos", target_os = "linux"))))]
 mod unsupported;
 
-#[cfg(not(any(target_os = "freebsd", target_os = "netbsd", target_os = "macos", target_os = "linux")))]
+#[cfg(all(feature = "unsupported", not(any(target_os = "freebsd", target_os = "netbsd", target_os = "macos", target_os = "linux"))))]
 pub use self::unsupported::*;
 
 /// A constant indicating whether or not the target platform is supported.
 ///
 /// To make programmer's lives easier, this library builds on all platforms.
 /// However, all function calls on unsupported platforms will return io::Errors.
+///
+/// Note: If you would like compilation to simply fail on unsupported platforms,
+/// turn of the `unsupported` feature.
 pub const SUPPORTED_PLATFORM: bool = cfg!(any(target_os = "freebsd",
                                               target_os = "netbsd",
                                               target_os = "macos",

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -1,4 +1,3 @@
-
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 mod linux_macos;
 
@@ -10,3 +9,18 @@ mod bsd;
 
 #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
 pub use self::bsd::*;
+
+#[cfg(not(any(target_os = "freebsd", target_os = "netbsd", target_os = "macos", target_os = "linux")))]
+mod unsupported;
+
+#[cfg(not(any(target_os = "freebsd", target_os = "netbsd", target_os = "macos", target_os = "linux")))]
+pub use self::unsupported::*;
+
+/// A constant indicating whether or not the target platform is supported.
+///
+/// To make programmer's lives easier, this library builds on all platforms.
+/// However, all function calls on unsupported platforms will return io::Errors.
+pub const SUPPORTED_PLATFORM: bool = cfg!(any(target_os = "freebsd",
+                                              target_os = "netbsd",
+                                              target_os = "macos",
+                                              target_os = "linux"));

--- a/src/sys/unsupported.rs
+++ b/src/sys/unsupported.rs
@@ -1,0 +1,52 @@
+use std::ffi::{OsStr, OsString};
+use std::os::unix::io::RawFd;
+use std::path::Path;
+use std::io;
+
+use ::UnsupportedPlatformError;
+
+#[derive(Clone, Debug)]
+pub struct XAttrs;
+
+impl Iterator for XAttrs {
+    type Item = OsString;
+    fn next(&mut self) -> Option<OsString> {
+        unreachable!("this should never exist")
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        unreachable!("this should never exist")
+    }
+}
+
+pub fn get_fd(_: RawFd, _: &OsStr) -> io::Result<Vec<u8>> {
+    Err(io::Error::new(io::ErrorKind::Other, UnsupportedPlatformError))
+}
+
+pub fn set_fd(_: RawFd, _: &OsStr, _: &[u8]) -> io::Result<()> {
+    Err(io::Error::new(io::ErrorKind::Other, UnsupportedPlatformError))
+}
+
+pub fn remove_fd(_: RawFd, _: &OsStr) -> io::Result<()> {
+    Err(io::Error::new(io::ErrorKind::Other, UnsupportedPlatformError))
+}
+
+pub fn list_fd(_: RawFd) -> io::Result<XAttrs> {
+    Err(io::Error::new(io::ErrorKind::Other, UnsupportedPlatformError))
+}
+
+pub fn get_path(_: &Path, _: &OsStr) -> io::Result<Vec<u8>> {
+    Err(io::Error::new(io::ErrorKind::Other, UnsupportedPlatformError))
+}
+
+pub fn set_path(_: &Path, _: &OsStr, _: &[u8]) -> io::Result<()> {
+    Err(io::Error::new(io::ErrorKind::Other, UnsupportedPlatformError))
+}
+
+pub fn remove_path(_: &Path, _: &OsStr) -> io::Result<()> {
+    Err(io::Error::new(io::ErrorKind::Other, UnsupportedPlatformError))
+}
+
+pub fn list_path(_: &Path) -> io::Result<XAttrs> {
+    Err(io::Error::new(io::ErrorKind::Other, UnsupportedPlatformError))
+}


### PR DESCRIPTION
This patch adds a dummy (mock) interface for unsupported platforms that always
returns errors. It also allows both compile-time (optional) and runtime
detection of unsupported platforms.

/cc @brson