### PR TITLE
Run tests on MacOS and fix new get

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,8 @@ use std::ptr;
 use std::ffi::CString;
 use std::path::Path;
 
-use libc::{ERANGE, ENODATA, ssize_t};
+use libc::{ERANGE, ENOATTR, ssize_t};
+
 
 #[allow(dead_code)]
 pub fn name_to_c(name: &OsStr) -> io::Result<CString> {
@@ -28,7 +29,7 @@ pub fn path_to_c(path: &Path) -> io::Result<CString> {
 
 pub fn extract_noattr(result: io::Result<Vec<u8>>) -> io::Result<Option<Vec<u8>>> {
     result.map(|v| Some(v)).or_else(|e| match e.raw_os_error() {
-        Some(ENODATA) => Ok(None),
+        Some(ENOATTR) => Ok(None),
         _ => Err(e),
     })
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -8,7 +8,7 @@ use xattr::FileExt;
 use tempfile::{tempfile_in, NamedTempFile};
 
 #[test]
-#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os="macos"))]
 fn test_fd() {
     use std::os::unix::ffi::OsStrExt;
     // Only works on "real" filesystems.
@@ -35,7 +35,7 @@ fn test_fd() {
 }
 
 #[test]
-#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os="macos"))]
 fn test_path() {
     use std::os::unix::ffi::OsStrExt;
     // Only works on "real" filesystems.
@@ -63,13 +63,13 @@ fn test_path() {
 
 
 #[test]
-#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os="macos"))]
 fn test_missing() {
     assert!(xattr::get("/var/empty/does-not-exist", "user.test").is_err());
 }
 
 #[test]
-#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os="macos"))]
 fn test_multi() {
     use std::os::unix::ffi::OsStrExt;
     // Only works on "real" filesystems.


### PR DESCRIPTION
On MacOS getxattr and fgetxattr return ENOATTR as the error code not ENODATA when the attribute is not found. This fixes the problem.

I also noticed that the tests were disabled on MacOS but they run just fine on my mac so I have enabled them.