### PR TITLE
lib: add some more rustdocs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,30 @@
-//! Manage extended attributes.
+//! A pure-Rust library to manage extended attributes.
 //!
-//! Note: This library *does not* follow symlinks.
+//! It provides support for manipulating extended attributes
+//! (`xattrs`) on modern Unix filesystems. See the `attr(5)`
+//! manpage for more details.
+//!
+//! An extension trait [`FileExt`](::FileExt) is provided to directly work with
+//! standard `File` objects and file descriptors.
+//!
+//! NOTE: In case of a symlink as path argument, all methods
+//! in this library work on the symlink itself **without**
+//! de-referencing it.
+//!
+//! ```rust
+//! let mut xattrs = xattr::list("/").unwrap().peekable();
+//!
+//! if xattrs.peek().is_none() {
+//!     println!("no xattr set on root");
+//!     return;
+//! }
+//!
+//! println!("Extended attributes:");
+//! for attr in xattrs {
+//!     println!(" - {:?}", attr);
+//! }
+//! ```
+
 extern crate libc;
 
 mod error;
@@ -54,6 +78,7 @@ where
     sys::list_path(path.as_ref())
 }
 
+/// Extension trait to manipulate extended attributes on `File`-like objects.
 pub trait FileExt: AsRawFd {
     /// Get an extended attribute for the specified file.
     fn get_xattr<N>(&self, name: N) -> io::Result<Option<Vec<u8>>>

--- a/src/sys/bsd.rs
+++ b/src/sys/bsd.rs
@@ -70,6 +70,7 @@ extern "C" {
     ) -> ssize_t;
 }
 
+/// An iterator over a set of extended attributes names.
 pub struct XAttrs {
     user_attrs: Box<[u8]>,
     system_attrs: Box<[u8]>,

--- a/src/sys/linux_macos/mod.rs
+++ b/src/sys/linux_macos/mod.rs
@@ -21,6 +21,7 @@ use libc::{c_char, c_void, size_t};
 
 use util::{allocate_loop, name_to_c, path_to_c};
 
+/// An iterator over a set of extended attributes names.
 pub struct XAttrs {
     data: Box<[u8]>,
     offset: usize,
@@ -43,7 +44,7 @@ impl Clone for XAttrs {
 }
 
 // Yes, I could avoid these allocations on linux/macos. However, if we ever want to be freebsd
-// compatable, we need to be able to prepend the namespace to the extended attribute names.
+// compatible, we need to be able to prepend the namespace to the extended attribute names.
 // Furthermore, borrowing makes the API messy.
 impl Iterator for XAttrs {
     type Item = OsString;

--- a/src/sys/unsupported.rs
+++ b/src/sys/unsupported.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 use UnsupportedPlatformError;
 
+/// An iterator over a set of extended attributes names.
 #[derive(Clone, Debug)]
 pub struct XAttrs;
 


### PR DESCRIPTION
This adds a few missing docstrings on public entries, it expands the
crate description and provides a very simple example too.