### PR TITLE
build all platforms when testing

### DIFF
--- a/src/sys/bsd.rs
+++ b/src/sys/bsd.rs
@@ -10,8 +10,6 @@ use std::path::Path;
 use libc::{c_char, c_int, c_void, size_t, ssize_t, EPERM};
 use util::{allocate_loop, path_to_c};
 
-pub const ENOATTR: ::libc::c_int = ::libc::ENOATTR;
-
 const EXTATTR_NAMESPACE_USER_STRING: &'static str = "user";
 const EXTATTR_NAMESPACE_SYSTEM_STRING: &'static str = "system";
 const EXTATTR_NAMESPACE_NAMES: [&'static str; 3] = [

--- a/src/sys/linux_macos/mod.rs
+++ b/src/sys/linux_macos/mod.rs
@@ -21,8 +21,6 @@ use libc::{c_char, c_void, size_t};
 
 use util::{allocate_loop, name_to_c, path_to_c};
 
-pub const ENOATTR: ::libc::c_int = ::libc::ENOATTR;
-
 /// An iterator over a set of extended attributes names.
 pub struct XAttrs {
     data: Box<[u8]>,

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -7,6 +7,9 @@ macro_rules! platforms {
 
             #[cfg(any($(target_os = $platform),*))]
             pub use self::$module::*;
+
+            #[cfg(any($(target_os = $platform),*))]
+            pub const ENOATTR: ::libc::c_int = ::libc::ENOATTR;
         )*
 
         #[cfg(any(test, all(feature = "unsupported", not(any($($(target_os = $platform),*),*)))))]
@@ -15,6 +18,9 @@ macro_rules! platforms {
 
         #[cfg(all(feature = "unsupported", not(any($($(target_os = $platform),*),*))))]
         pub use self::unsupported::*;
+        #[cfg(all(feature = "unsupported", not(any($($(target_os = $platform),*),*))))]
+        pub const ENOATTR: ::libc::c_int = 0;
+
 
         /// A constant indicating whether or not the target platform is supported.
         ///

--- a/src/sys/unsupported.rs
+++ b/src/sys/unsupported.rs
@@ -5,9 +5,6 @@ use std::path::Path;
 
 use UnsupportedPlatformError;
 
-// Need to use something.
-pub const ENOATTR: ::libc::c_int = 0;
-
 /// An iterator over a set of extended attributes names.
 #[derive(Clone, Debug)]
 pub struct XAttrs;


### PR DESCRIPTION
(and macroify the platform code a bit)

We may need to remove this if we ever add code that simply won't *compile* on
other platforms but this makes hacking on this package easier.