### PR TITLE
add Android as supported platform

### DIFF
--- a/src/sys/linux_macos/mod.rs
+++ b/src/sys/linux_macos/mod.rs
@@ -1,7 +1,7 @@
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use self::linux::*;
 
 #[cfg(target_os = "macos")]

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -35,6 +35,6 @@ macro_rules! platforms {
 }
 
 platforms! {
-    "linux"; "macos" => linux_macos,
+    "android"; "linux"; "macos" => linux_macos,
     "freebsd"; "netbsd" => bsd
 }


### PR DESCRIPTION
This doesn't get most the tests working, since they rely on paths android doesn't have, but I confirmed locally that if `/var/tmp` were replaced with a path that exists (and android added to the relevant `cfg` statements), all the tests do pass.