### PR TITLE
fix: use ErrorKind::Unsupported where the platform is unsupported

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use std::fmt;
 /// The error type returned on unsupported platforms.
 ///
 /// On unsupported platforms, all operations will fail with an `io::Error` with
-/// a kind `io::ErrorKind::Other` and an `UnsupportedPlatformError` error as the inner error.
+/// a kind `io::ErrorKind::Unsupported` and an `UnsupportedPlatformError` error as the inner error.
 /// While you *could* check the inner error, it's probably simpler just to check
 /// `xattr::SUPPORTED_PLATFORM`.
 ///

--- a/src/sys/unsupported.rs
+++ b/src/sys/unsupported.rs
@@ -22,56 +22,56 @@ impl Iterator for XAttrs {
 
 pub fn get_fd(_: RawFd, _: &OsStr) -> io::Result<Vec<u8>> {
     Err(io::Error::new(
-        io::ErrorKind::Other,
+        io::ErrorKind::Unsupported,
         UnsupportedPlatformError,
     ))
 }
 
 pub fn set_fd(_: RawFd, _: &OsStr, _: &[u8]) -> io::Result<()> {
     Err(io::Error::new(
-        io::ErrorKind::Other,
+        io::ErrorKind::Unsupported,
         UnsupportedPlatformError,
     ))
 }
 
 pub fn remove_fd(_: RawFd, _: &OsStr) -> io::Result<()> {
     Err(io::Error::new(
-        io::ErrorKind::Other,
+        io::ErrorKind::Unsupported,
         UnsupportedPlatformError,
     ))
 }
 
 pub fn list_fd(_: RawFd) -> io::Result<XAttrs> {
     Err(io::Error::new(
-        io::ErrorKind::Other,
+        io::ErrorKind::Unsupported,
         UnsupportedPlatformError,
     ))
 }
 
 pub fn get_path(_: &Path, _: &OsStr) -> io::Result<Vec<u8>> {
     Err(io::Error::new(
-        io::ErrorKind::Other,
+        io::ErrorKind::Unsupported,
         UnsupportedPlatformError,
     ))
 }
 
 pub fn set_path(_: &Path, _: &OsStr, _: &[u8]) -> io::Result<()> {
     Err(io::Error::new(
-        io::ErrorKind::Other,
+        io::ErrorKind::Unsupported,
         UnsupportedPlatformError,
     ))
 }
 
 pub fn remove_path(_: &Path, _: &OsStr) -> io::Result<()> {
     Err(io::Error::new(
-        io::ErrorKind::Other,
+        io::ErrorKind::Unsupported,
         UnsupportedPlatformError,
     ))
 }
 
 pub fn list_path(_: &Path) -> io::Result<XAttrs> {
     Err(io::Error::new(
-        io::ErrorKind::Other,
+        io::ErrorKind::Unsupported,
         UnsupportedPlatformError,
     ))
 }


### PR DESCRIPTION
Consistent with stdlib.