### PR TITLE
Use libc's definitions where possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default = ["unsupported"]
 unsupported = []
 
 [dependencies]
-libc = "0.2"
+libc = "0.2.44"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/sys/linux_macos/linux.rs
+++ b/src/sys/linux_macos/linux.rs
@@ -1,35 +1,14 @@
-use libc::{c_char, c_int, c_void, size_t, ssize_t};
-
-extern "C" {
-    pub fn flistxattr(fd: c_int, buf: *mut c_char, size: size_t) -> ssize_t;
-    pub fn fgetxattr(fd: c_int, name: *const c_char, value: *mut c_void, size: size_t) -> ssize_t;
-    pub fn fremovexattr(fd: c_int, name: *const c_char) -> c_int;
-
-    pub fn llistxattr(path: *const c_char, buf: *mut c_char, size: size_t) -> ssize_t;
-    pub fn lgetxattr(
-        path: *const c_char,
-        name: *const c_char,
-        value: *mut c_void,
-        size: size_t,
-    ) -> ssize_t;
-    pub fn lremovexattr(path: *const c_char, name: *const c_char) -> c_int;
-}
+use libc::{c_char, c_int, c_void, size_t};
+pub use libc::{fgetxattr, flistxattr, fremovexattr, lgetxattr, llistxattr,
+           lremovexattr};
 
 pub unsafe fn fsetxattr(
     fd: c_int,
     name: *const c_char,
     value: *const c_void,
     size: size_t,
-) -> ssize_t {
-    extern "C" {
-        fn fsetxattr(
-            fd: c_int,
-            name: *const c_char,
-            value: *const c_void,
-            size: size_t,
-            flags: c_int,
-        ) -> ssize_t;
-    }
+) -> c_int {
+    use libc::fsetxattr;
     fsetxattr(fd, name, value, size, 0)
 }
 
@@ -38,15 +17,7 @@ pub unsafe fn lsetxattr(
     name: *const c_char,
     value: *const c_void,
     size: size_t,
-) -> ssize_t {
-    extern "C" {
-        fn lsetxattr(
-            path: *const c_char,
-            name: *const c_char,
-            value: *const c_void,
-            size: size_t,
-            flags: c_int,
-        ) -> ssize_t;
-    }
+) -> c_int {
+    use libc::lsetxattr;
     lsetxattr(path, name, value, size, 0)
 }

--- a/src/sys/linux_macos/macos.rs
+++ b/src/sys/linux_macos/macos.rs
@@ -4,9 +4,7 @@ const XATTR_NOFOLLOW: c_int = 0x0001;
 
 #[inline(always)]
 pub unsafe fn fremovexattr(fd: c_int, name: *const c_char) -> c_int {
-    extern "C" {
-        fn fremovexattr(fd: c_int, name: *const c_char, options: c_int) -> c_int;
-    }
+    use libc::fremovexattr;
     fremovexattr(fd, name, 0)
 }
 
@@ -16,17 +14,8 @@ pub unsafe fn fsetxattr(
     name: *const c_char,
     value: *const c_void,
     size: size_t,
-) -> ssize_t {
-    extern "C" {
-        fn fsetxattr(
-            fd: c_int,
-            name: *const c_char,
-            value: *const c_void,
-            size: size_t,
-            position: uint32_t,
-            options: c_int,
-        ) -> ssize_t;
-    }
+) -> c_int {
+    use libc::fsetxattr;
     fsetxattr(fd, name, value, size, 0, 0)
 }
 
@@ -37,32 +26,19 @@ pub unsafe fn fgetxattr(
     value: *mut c_void,
     size: size_t,
 ) -> ssize_t {
-    extern "C" {
-        fn fgetxattr(
-            fd: c_int,
-            name: *const c_char,
-            value: *mut c_void,
-            size: size_t,
-            position: uint32_t,
-            options: c_int,
-        ) -> ssize_t;
-    }
+    use libc::fgetxattr;
     fgetxattr(fd, name, value, size, 0, 0)
 }
 
 #[inline(always)]
 pub unsafe fn flistxattr(fd: c_int, buf: *mut c_char, size: size_t) -> ssize_t {
-    extern "C" {
-        fn flistxattr(fd: c_int, buf: *mut c_char, size: size_t, options: c_int) -> ssize_t;
-    }
+    use libc::flistxattr;
     flistxattr(fd, buf, size, 0)
 }
 
 #[inline(always)]
 pub unsafe fn lremovexattr(path: *const c_char, name: *const c_char) -> c_int {
-    extern "C" {
-        fn removexattr(path: *const c_char, name: *const c_char, options: c_int) -> c_int;
-    }
+    use libc::removexattr;
     removexattr(path, name, XATTR_NOFOLLOW)
 }
 
@@ -73,16 +49,7 @@ pub unsafe fn lsetxattr(
     value: *const c_void,
     size: size_t,
 ) -> ssize_t {
-    extern "C" {
-        fn setxattr(
-            path: *const c_char,
-            name: *const c_char,
-            value: *const c_void,
-            size: size_t,
-            position: uint32_t,
-            options: c_int,
-        ) -> ssize_t;
-    }
+    use libc::setxattr;
     setxattr(path, name, value, size, 0, XATTR_NOFOLLOW)
 }
 
@@ -93,28 +60,12 @@ pub unsafe fn lgetxattr(
     value: *mut c_void,
     size: size_t,
 ) -> ssize_t {
-    extern "C" {
-        fn getxattr(
-            path: *const c_char,
-            name: *const c_char,
-            value: *mut c_void,
-            size: size_t,
-            position: uint32_t,
-            options: c_int,
-        ) -> ssize_t;
-    }
+    use libc::getxattr;
     getxattr(path, name, value, size, 0, XATTR_NOFOLLOW)
 }
 
 #[inline(always)]
 pub unsafe fn llistxattr(path: *const c_char, buf: *mut c_char, size: size_t) -> ssize_t {
-    extern "C" {
-        fn listxattr(
-            path: *const c_char,
-            buf: *mut c_char,
-            size: size_t,
-            options: c_int,
-        ) -> ssize_t;
-    }
+    use libc::listxattr;
     listxattr(path, buf, size, XATTR_NOFOLLOW)
 }


### PR DESCRIPTION
This not only reduces total code size (since xattr already depends on libc anyway), but also leverages libc's CI to ensure that the FFI bindings are correct.