### PR TITLE
chore: release 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xattr"
 edition = "2021"
-version = "0.2.3"
+version = "1.0.0"
 authors = ["Steven Allen <steven@stebalien.com>"]
 description = "unix extended filesystem attributes"
 


### PR DESCRIPTION
- Move to rust 2021 edition.
- Use libc for most syscall definitions.

BREAKING: Change the unsupported error kind from `io::ErrorKind::Other` to `io::ErrorKind::Unsupported`