### PR TITLE
Resolve import of UnsupportedPlatformError

### DIFF
--- a/src/sys/unsupported.rs
+++ b/src/sys/unsupported.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::os::unix::io::RawFd;
 use std::path::Path;
 
-use UnsupportedPlatformError;
+use crate::UnsupportedPlatformError;
 
 /// An iterator over a set of extended attributes names.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This fix allows the crate to build (with no-op support) on OpenBSD.