### PR TITLE
CI: add GitHub actions for testing on Linux, MacOS, FreeBSD

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,0 +1,31 @@
+# Run cargo tests in a FreeBSD VM. This needs to run on one of the GitHub macos runners, because
+# they are currently the only ones to support virtualization.
+#
+# See https://github.com/vmactions/freebsd-vm
+
+on: [push]
+
+name: freebsd
+
+jobs:
+  test:
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run tests in FreeBSD VM
+      uses: vmactions/freebsd-vm@v0
+      with:
+        usesh: true
+        prepare: |
+          pkg install -y curl
+          curl https://sh.rustup.rs -sSf --output rustup.sh
+          sh rustup.sh -y --profile minimal --default-toolchain stable
+          export PATH="${HOME}/.cargo/bin:$PATH"
+          echo "~~~~ rustc --version ~~~~"
+          rustc --version
+
+        run: |
+          export PATH="${HOME}/.cargo/bin:$PATH"
+          ls -la
+          cargo build --verbose
+          cargo test --verbose

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,13 @@
+on: [push]
+
+name: linux
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+    - run: cargo build --verbose
+    - run: cargo test --verbose

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,13 @@
+on: [push]
+
+name: macos
+
+jobs:
+  build:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+    - run: cargo build --verbose
+    - run: cargo test --verbose

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -1,0 +1,36 @@
+# Run cargo tests in a NetBSD VM. This needs to run on one of the GitHub macos runners, because
+# they are currently the only ones to support virtualization.
+#
+# See https://github.com/vmactions/netbsd-vm
+#
+# The standard filesystem on NetBSD installs, ffs, doesn't support extended attributes. The
+# filesystem type needs to be set fo FFSv2ea (on NetBSD 10 or later) for this to be enabled.
+# See http://wikimirror.netbsd.de/tutorials/acls_and_extended_attributes_on_ffs/
+
+# Disabled until NetBSD 10 is released and available via vmactions
+on: workflow_dispatch
+
+name: netbsd
+
+jobs:
+  test:
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run tests in NetBSD VM
+      uses: vmactions/netbsd-vm@v0
+      with:
+        usesh: true
+        prepare: |
+          /usr/sbin/pkg_add curl
+          curl https://sh.rustup.rs -sSf --output rustup.sh
+          sh rustup.sh -y --profile minimal --default-toolchain stable
+          export PATH="${HOME}/.cargo/bin:$PATH"
+          echo "~~~~ rustc --version ~~~~"
+          rustc --version
+
+        run: |
+          export PATH="${HOME}/.cargo/bin:$PATH"
+          ls -la
+          cargo build --verbose
+          cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default = ["unsupported"]
 unsupported = []
 
 [dependencies]
-libc = "0.2.44"
+libc = "0.2.147"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 xattr
 =====
 
-[![Build Status](https://api.cirrus-ci.com/github/Stebalien/xattr.svg)](https://cirrus-ci.com/github/Stebalien/xattr)
+[![CI](https://github.com/Stebalien/xattr/workflows/build/badge.svg)](https://github.com/Stebalien/xattr/workflows/build/badge.svg)
 
 A small library for setting, getting, and listing extended attributes.
 
 Supported Platforms: Android, Linux, MacOS, FreeBSD, and NetBSD.
 
-API Documentation: https://stebalien.github.com/xattr/xattr/
+API Documentation: https://docs.rs/xattr/latest/xattr/
 
 Unsupported Platforms
 --------------------------
 
-This library includes no-op support for unsupported platforms. That is, it will
-build on *all* platforms but always fail on unsupported platforms.
+This library includes no-op support for unsupported Unix platforms. That is, it will
+build on *all* Unix platforms but always fail on unsupported Unix platforms.
 
 1. You can turn this off by disabling the default `unsupported` feature. If you
    do so, this library will fail to compile on unsupported platforms.


### PR DESCRIPTION
Add GitHub actions to build and run the tests on Linux and MacOS natively, and on a VM for FreeBSD. There is also an action for NetBSD builds but it is disabled due to lack of support for extended attributes in the current release (with default options). 