### PR TITLE
chore: remove CI badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 xattr
 =====
 
-[![CI](https://github.com/Stebalien/xattr/workflows/build/badge.svg)](https://github.com/Stebalien/xattr/workflows/build/badge.svg)
-
 A small library for setting, getting, and listing extended attributes.
 
 Supported Platforms: Android, Linux, MacOS, FreeBSD, and NetBSD.


### PR DESCRIPTION
It's broken and doesn't really add anything over the commit status. To fix it, we'd need to have one badge per platform.