### PR TITLE
Add deref test

### DIFF
--- a/tests/main.rs
+++ b/tests/main.rs
@@ -112,3 +112,44 @@ fn test_multi() {
     }
     assert!(items.is_empty());
 }
+
+// Tests the deref API variants - regression test for
+// https://github.com/Stebalien/xattr/issues/57
+#[test]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
+fn test_path_deref() {
+    use std::os::unix::ffi::OsStrExt;
+    // Only works on "real" filesystems.
+    let tmp = NamedTempFile::new_in("/var/tmp").unwrap();
+    assert!(xattr::get_deref(tmp.path(), "user.test").unwrap().is_none());
+    assert_eq!(
+        xattr::list_deref(tmp.path())
+            .unwrap()
+            .filter(|x| x.as_bytes().starts_with(b"user."))
+            .count(),
+        0
+    );
+
+    xattr::set_deref(tmp.path(), "user.test", b"my test").unwrap();
+    assert_eq!(
+        xattr::get_deref(tmp.path(), "user.test").unwrap().unwrap(),
+        b"my test"
+    );
+    assert_eq!(
+        xattr::list_deref(tmp.path())
+            .unwrap()
+            .filter(|x| x.as_bytes().starts_with(b"user."))
+            .collect::<Vec<_>>(),
+        vec![OsStr::new("user.test")]
+    );
+
+    xattr::remove_deref(tmp.path(), "user.test").unwrap();
+    assert!(xattr::get_deref(tmp.path(), "user.test").unwrap().is_none());
+    assert_eq!(
+        xattr::list_deref(tmp.path())
+            .unwrap()
+            .filter(|x| x.as_bytes().starts_with(b"user."))
+            .count(),
+        0
+    );
+}


### PR DESCRIPTION
As requested in https://github.com/Stebalien/xattr/issues/57 I've created a failing regression test. This is just a copy of the existing `test_path` using the deref API variants. So it's also exercising set_deref/remove_deref/list_deref (those ones don't cause any problems yet).

cargo test output:
```
$ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.02s
     Running unittests src/lib.rs (target/debug/deps/xattr-c5ae2acac45a8796)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/main.rs (target/debug/deps/main-1a74d7ef0eef6ac8)

running 5 tests
test test_missing ... ok
test test_fd ... ok
test test_multi ... ok
test test_path ... ok
test test_path_deref ... FAILED

failures:

---- test_path_deref stdout ----
thread 'test_path_deref' panicked at tests/main.rs:135:51:
called `Result::unwrap()` on an `Err` value: Os { code: 34, kind: Uncategorized, message: "Result too large" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_path_deref

test result: FAILED. 4 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

error: test failed, to rerun pass `--test main`
```