### PR TITLE
Implement Default for XAttrs structs

### DIFF
--- a/src/sys/bsd.rs
+++ b/src/sys/bsd.rs
@@ -44,6 +44,7 @@ fn slice_parts(buf: &mut [u8]) -> (*mut c_void, size_t) {
 }
 
 /// An iterator over a set of extended attributes names.
+#[derive(Default)]
 pub struct XAttrs {
     user_attrs: Box<[u8]>,
     system_attrs: Box<[u8]>,

--- a/src/sys/linux_macos.rs
+++ b/src/sys/linux_macos.rs
@@ -26,6 +26,7 @@ fn as_listxattr_buffer(buf: &mut [u8]) -> &mut [c_char] {
 }
 
 /// An iterator over a set of extended attributes names.
+#[derive(Default)]
 pub struct XAttrs {
     data: Box<[u8]>,
     offset: usize,

--- a/src/sys/unsupported.rs
+++ b/src/sys/unsupported.rs
@@ -8,17 +8,17 @@ use crate::UnsupportedPlatformError;
 pub const ENOATTR: i32 = 0;
 
 /// An iterator over a set of extended attributes names.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct XAttrs;
 
 impl Iterator for XAttrs {
     type Item = OsString;
     fn next(&mut self) -> Option<OsString> {
-        unreachable!("this should never exist")
+        None
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        unreachable!("this should never exist")
+        (0, Some(0))
     }
 }
 


### PR DESCRIPTION
This is convenient in cases where you sometimes need to list the attributes, and sometimes don't (requiring ether a dance with `Option` or the ability to construct an empty XAttrs).

At the same time, make the "unsupported" XAttrs act like it's empty instead of panicing.