### PR TITLE
Implement Debug for XAttrs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,9 @@ mod util;
 
 use std::ffi::OsStr;
 use std::fs::File;
-use std::io;
 use std::os::unix::io::{AsRawFd, BorrowedFd};
 use std::path::Path;
+use std::{fmt, io};
 
 pub use error::UnsupportedPlatformError;
 pub use sys::{XAttrs, SUPPORTED_PLATFORM};
@@ -153,3 +153,16 @@ pub trait FileExt: AsRawFd {
 }
 
 impl FileExt for File {}
+
+impl fmt::Debug for XAttrs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Waiting on https://github.com/rust-lang/rust/issues/117729 to stabilize...
+        struct AsList<'a>(&'a XAttrs);
+        impl<'a> fmt::Debug for AsList<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_list().entries(self.0.clone()).finish()
+            }
+        }
+        f.debug_tuple("XAttrs").field(&AsList(self)).finish()
+    }
+}

--- a/src/sys/unsupported.rs
+++ b/src/sys/unsupported.rs
@@ -8,7 +8,7 @@ use crate::UnsupportedPlatformError;
 pub const ENOATTR: i32 = 0;
 
 /// An iterator over a set of extended attributes names.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default)]
 pub struct XAttrs;
 
 impl Iterator for XAttrs {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -87,6 +87,28 @@ fn test_missing() {
 
 #[test]
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
+fn test_debug() {
+    // Only works on "real" filesystems.
+    let tmp = tempfile_in("/var/tmp").unwrap();
+
+    tmp.set_xattr("user.myattr", b"value").unwrap();
+    let mut attrs = tmp.list_xattr().unwrap();
+
+    // Debug is idempotent
+    assert_eq!(format!("{:?}", attrs), format!("{:?}", attrs));
+
+    // It produces the right value.
+    assert_eq!(r#"XAttrs(["user.myattr"])"#, format!("{:?}", attrs));
+
+    // It doesn't affect the underlying iterator.
+    assert_eq!("user.myattr", attrs.next().unwrap());
+
+    // An empty iterator produces the right value.
+    assert_eq!(r#"XAttrs([])"#, format!("{:?}", attrs));
+}
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
 fn test_multi() {
     use std::os::unix::ffi::OsStrExt;
     // Only works on "real" filesystems.


### PR DESCRIPTION
This implementation allocates and likely doesn't need to but... it's for debugging and it means I have to write/maintain less code which is especially important as this code runs on many platforms that don't get extensively tested.

fixes #62