### PR TITLE
Call fn once in loop if possible 

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -14,16 +14,11 @@ pub fn extract_noattr(result: io::Result<Vec<u8>>) -> io::Result<Option<Vec<u8>>
 pub fn allocate_loop<E, F: FnMut(&mut [u8]) -> Result<usize, E>>(mut f: F) -> io::Result<Vec<u8>>
 where
     io::Error: From<E>,
-{
-    let mut vec: Vec<u8> = Vec::new();
-    loop {
-        let ret = f(&mut [])?;
-        vec.resize(ret, 0);
+{    loop {
+        let mut vec: Vec<u8> = Vec::new();
 
         match f(&mut vec) {
             Ok(size) => {
-                vec.truncate(size);
-                vec.shrink_to_fit();
                 return Ok(vec);
             }
 


### PR DESCRIPTION
Calling twice inflates number and time spent re: the `llistxattr` call.

```
➜  coreutils git:(store_xattrs) ✗ strace -c ~/program/coreutils/target/release/ls -al ~
...
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
 22.59    0.001678          12       132           llistxattr
 12.95    0.000962          28        34           getdents64
 12.53    0.000931          11        80         7 statx
 11.09    0.000824         824         1           execve
  6.95    0.000516          17        29         2 openat
  4.67    0.000347          26        13           read
  4.56    0.000339          26        13           mmap
  4.07    0.000302           9        31           close
  3.86    0.000287          11        24        14 readlink
  3.45    0.000256           9        27           fstat
  1.64    0.000122          24         5           mprotect
  1.56    0.000116          29         4         4 connect
  1.53    0.000114          19         6           brk
  1.43    0.000106         106         1           write
  1.08    0.000080          20         4           socket
  1.06    0.000079          39         2           munmap
  0.97    0.000072          12         6           newfstatat
  0.70    0.000052           7         7           rt_sigaction
  0.61    0.000045           9         5           ioctl
  0.46    0.000034           6         5           lseek
  0.35    0.000026          13         2           pread64
  0.28    0.000021          10         2           getrandom
  0.27    0.000020          10         2           prlimit64
  0.26    0.000019          19         1         1 access
  0.24    0.000018          18         1           poll
  0.24    0.000018           6         3           sigaltstack
  0.13    0.000010          10         1           arch_prctl
  0.12    0.000009           9         1           sched_getaffinity
  0.12    0.000009           9         1           rseq
  0.11    0.000008           8         1           set_tid_address
  0.11    0.000008           8         1           set_robust_list
------ ----------- ----------- --------- --------- ------------------
100.00    0.007428          16       445        28 total
```