### PR TITLE
Exclude a script file from the published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/xattr"
 repository = "https://github.com/Stebalien/xattr"
 keywords = ["xattr", "filesystem", "unix"]
 license = "MIT OR Apache-2.0"
+include = ["README.md", "LICENSE-*", "Cargo.toml", "src/**/*.rs", "tests/**/*.rs"]
 
 [features]
 default = ["unsupported"]


### PR DESCRIPTION
During a dependency review we noticed that the xattr crate includes a ci script file. This file is not required for building xattr as depndency. The script file might at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from beeing included in the published packages to make sure that everything that's included is an conscious choice.